### PR TITLE
ADE/FDE are erroneously doubly-divided by the batch size

### DIFF
--- a/ours/def_train_eval.py
+++ b/ours/def_train_eval.py
@@ -449,7 +449,7 @@ def compute_accuracy_stream1(traindataloader, labeldataloader, encoder, decoder,
         mse = np.sqrt(mse)
         ade += mse
         fde += mse[-1]
-        count += testbatch_in_form.size()[0]
+        count += 1
     
     ade = ade/count
     fde = fde/count


### PR DESCRIPTION
After computing the ADE, it is twice divided by the batch size. The first time is in the `MSE` function (line 481)
```
lossVal = np.sum(acc, axis=0)/len(acc)
```
and the second time is after being returned in line 454
```
ade = ade/count
```
where `count` is `batch_size * n_epochs`. However, `count` should only be `n_epochs` as the ADE was already averaged over `batch_size` in line 481.

This causes the ADE/FDE values to be erroneously scaled down by 128 times (since the default evaluation `batch_size` is 128). This means the ADE/FDE values reported in the paper are also erroneously scaled down.

We believe the fix for this is to change line 452 to be
```
count += 1
```

As an addendum, even when first reading the paper these results jump out. Single-digit millimeters of prediction error over 3 to 5 seconds are _extraordinary_ results, multiple orders of magnitude better than existing methods for trajectory forecasting (and even very expensive differential GPS systems)!

Please update the paper ASAP to reflect these new values, since this materially changes its main conclusions.